### PR TITLE
Publish release and NuGet package

### DIFF
--- a/.github/workflows/build-and-test/action.yml
+++ b/.github/workflows/build-and-test/action.yml
@@ -1,0 +1,28 @@
+name: "Build And Test Action"
+description: "Builds and Tests bindle-dotnet"
+inputs:
+  configuration: 
+    description: 'The Configration to build and test'
+    required: true
+    default: 'release'
+runs:
+  using: "composite"
+  steps: 
+    - name: Restore dependencies
+      run: dotnet restore
+      shell: bash
+    - name: Set MINVERBUILDMETADATA
+      run: echo MINVERBUILDMETADATA=$(git rev-parse --short ${GITHUB_SHA})  >> $GITHUB_ENV
+      shell: bash
+    - name: Build
+      run: dotnet build -c ${{ inputs.configuration }}
+      shell: bash
+    - name: Build Bindle
+      run: make build
+      working-directory: bindleserver
+      shell: bash
+    - name: Test
+      env:  
+        BINDLE_SERVER_PATH: ../../../../bindleserver/target/debug
+      run: dotnet test 
+      shell: bash

--- a/.github/workflows/build-publish-release.yml
+++ b/.github/workflows/build-publish-release.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         configuration: ${{ matrix.config }}
   publish:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
     - name: Fetch Source
@@ -130,7 +130,6 @@ jobs:
           done
       shell: bash    
     - name: Publish Nuget Packages
-      if: startsWith( github.ref, 'refs/tags/' )
       run: |
           for nupkg in $(find . -name *.nupkg)
           do

--- a/.github/workflows/build-publish-release.yml
+++ b/.github/workflows/build-publish-release.yml
@@ -1,0 +1,140 @@
+name: dotnet
+
+on:
+  push:
+    tags: 
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-preview'
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [linux-debug, linux-release, macos-debug, macos-release, windows-debug, windows-release]
+        include:
+          - build: linux-debug
+            os: ubuntu-latest
+            config: debug
+          - build: linux-release
+            os: ubuntu-latest
+            config: release
+          - build: macos-debug
+            os: macos-latest
+            config: debug
+          - build: macos-release
+            os: macos-latest
+            config: release
+          - build: windows-debug
+            os: windows-latest
+            config: debug
+          - build: windows-release
+            os: windows-latest
+            config: release
+
+    steps:
+    - name: Fetch Source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get Bindle source for testing
+      uses: actions/checkout@v2
+      with:
+        repository: deislabs/bindle
+        path: bindleserver
+        ref: main
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - uses: ./.github/workflows/build-and-test
+      with:
+        configuration: ${{ matrix.config }}
+  publish:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch Source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get Bindle source for testing
+      uses: actions/checkout@v2
+      with:
+        repository: deislabs/bindle
+        path: bindleserver
+        ref: main
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - uses: ./.github/workflows/build-and-test
+      with:
+        configuration: Release
+    - name: Publish Github Packages
+      run: |
+           for nupkg in $(find . -name *.nupkg)
+           do
+            echo Pushing $nupkg
+            dotnet nuget push $nupkg --api-key ${{ secrets.GHPACKAGES_PAT }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --skip-duplicate
+           done
+      shell: bash
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fetch Source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get Bindle source for testing
+      uses: actions/checkout@v2
+      with:
+        repository: deislabs/bindle
+        path: bindleserver
+        ref: main
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - uses: ./.github/workflows/build-and-test
+      with:
+        configuration: Release
+    - name: "Build Changelog"
+      id: github_release
+      uses: mikepenz/release-changelog-builder-action@main
+      with:
+        configuration: ".github/workflows/configuration.json"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create Release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+        body: ${{ steps.github_release.outputs.changelog }}
+        prerelease: ${{ contains(github.ref, '-preview') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish Github Packages
+      run: |
+          for nupkg in $(find . -name *.nupkg)
+          do
+            echo Pushing $nupkg
+            dotnet nuget push $nupkg --api-key ${{ secrets.GHPACKAGES_PAT }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --skip-duplicate
+          done
+      shell: bash    
+    - name: Publish Nuget Packages
+      if: startsWith( github.ref, 'refs/tags/' )
+      run: |
+          for nupkg in $(find . -name *.nupkg)
+          do
+            echo Pushing $nupkg
+            dotnet nuget push $nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          done
+      shell: bash

--- a/.github/workflows/configuration.json
+++ b/.github/workflows/configuration.json
@@ -1,0 +1,34 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": [
+        "feature",
+        "enhancement"
+      ]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": [
+        "fix", 
+        "bug"
+      ]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": [
+        "test"
+      ]
+    },
+    {
+      "title": "## 📦 Dependencies",
+      "labels": [
+        "dependencies"
+      ]
+    },
+    {
+      "title": "## 🏷️ Uncategorized",
+      "labels": []
+    }
+  ]
+}

--- a/Bindle.Tests/Bindle.Tests.csproj
+++ b/Bindle.Tests/Bindle.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Bindle.Tests/Integration.cs
+++ b/Bindle.Tests/Integration.cs
@@ -1,14 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net.Sockets;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 using static Deislabs.Bindle.GetInvoiceOptions;
 
 namespace Deislabs.Bindle.Tests
@@ -22,134 +14,7 @@ namespace Deislabs.Bindle.Tests
     // Alternatively if you set the variable BINDLE_SERVER_PATH to the relative path of bindle-server then the test will start and stop the server automatically
     // e.g. if bindle is in a peer directory to bindle-dotnet and the debug build is being used then set the variable to "../../../../../bindle/target/debug"
 
-    public class IntegrationFixture : IDisposable
-    {
-        private Process process;
-        private string dataPath;
-        private string origFilePath;
-        private string copyFilePath;
-        public IntegrationFixture()
-        {
-            var bindlePath = Environment.GetEnvironmentVariable("BINDLE_SERVER_PATH");
-            if (!string.IsNullOrEmpty(bindlePath))
-            {
-                var fullPath = Path.GetFullPath(Path.Join(bindlePath, "bindle-server"));
-                dataPath = Path.GetFullPath(Path.Join("../../../data"));
-                Console.WriteLine($"Using Bindle Server Path: {fullPath}");
-                Console.WriteLine($"Using Test Data Path: {dataPath}");
-                var psi = new ProcessStartInfo
-                {
-                    FileName = fullPath,
-                    Arguments = $"-i 127.0.0.1:14044 -d {dataPath}",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true
-                };
-                psi.Environment["RUST_LOG"] = "info";
-                process = new Process
-                {
-                    StartInfo = psi
-                };
-                process.OutputDataReceived += (sender, e) =>
-                {
-                    if (!String.IsNullOrEmpty(e.Data))
-                    {
-                        Console.WriteLine(e.Data);
-                    }
-                };
-                process.ErrorDataReceived += (sender, e) =>
-                {
-                    if (!String.IsNullOrEmpty(e.Data))
-                    {
-                        Console.WriteLine(e.Data);
-                    }
-                };
-                process.Start();
-                process.BeginErrorReadLine();
-                process.BeginOutputReadLine();
-                // TODO: something a bit less crappy that this to wait for server to start:
-                Thread.Sleep(5000);
-                Assert.False(process.HasExited);
-
-                // data/invoices/33d7f76b3077de5b72f50d3bf1997d6571770665732ac83b3bede75cf3c5fb67/invoice.toml gets modified by tests so take a copy so it can be reverted at the end.
-
-                origFilePath = Path.Join(dataPath, "invoices/33d7f76b3077de5b72f50d3bf1997d6571770665732ac83b3bede75cf3c5fb67/invoice.toml");
-                copyFilePath = Path.Join(dataPath, "invoices/33d7f76b3077de5b72f50d3bf1997d6571770665732ac83b3bede75cf3c5fb67/invoice.toml.copy");
-                File.Copy(origFilePath, copyFilePath);
-
-            }
-        }
-
-        public void Dispose()
-        {
-
-            // Stop the bindle server
-            try
-            {
-                process?.Kill();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Failed to stop bindle process:{ex}");
-            }
-
-            // Delete the files and dirs that the tests created.
-
-            var dirs = new string[]
-            {
-                Path.Join(dataPath, "invoices/8fb420e8308462667f8e1585b7e768bf2e391aec9a29d13c968849c99ed5b0bf"),
-                Path.Join(dataPath, "parcels/460d5965e4d1909e8c7a3748a414956b7038ab5fd79937c9fcb2b214e6b0160a")
-            };
-
-            foreach (var dir in dirs)
-            {
-                if (Directory.Exists(dir))
-                {
-                    try
-                    {
-                        Directory.Delete(dir, true);
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine($"Failed to delete test invoice directory: {dir} : {ex}");
-                    }
-
-                }
-            }
-
-            // Revert the modifications
-            
-            if (File.Exists(copyFilePath))
-            {
-                try
-                {
-                    File.Move(copyFilePath, origFilePath, true);
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Failed to delete replace modified test invoice:{ex}");
-                }
-            }
-        }
-    }
-
-    // This is a quick and dirty way of ensuring that CanFetchInvoice runs before CanYankInvoice
-    public class AlphabeticalOrderer : ITestCaseOrderer
-    {
-        public IEnumerable<T> OrderTestCases<T>(IEnumerable<T> testCases) where T : ITestCase
-        {
-            Console.WriteLine($"Test Case Order:");
-            var orderedTestCases = testCases.OrderBy(testCase => testCase.TestMethod.Method.Name);
-            foreach (var tc in orderedTestCases)
-            {
-                Console.WriteLine($"\t{tc.TestMethod.Method.Name}");
-                yield return tc;
-            }
-        }
-    }
-
-    [TestCaseOrderer("Deislabs.Bindle.Tests.AlphabeticalOrderer", "Bindle.Tests")]
+    [TestCaseOrderer("Deislabs.Bindle.Tests.TestPriorityOrderer", "Bindle.Tests")]
     public class Integration : IClassFixture<IntegrationFixture>
     {
         const string DEMO_SERVER_URL = "http://localhost:14044/v1";
@@ -236,7 +101,9 @@ namespace Deislabs.Bindle.Tests
             Assert.Equal(invoice.Groups.Count, fetched.Groups.Count);
         }
 
+        // Make sure CanYankInvoice runs after CanCreateInvoice
         [Fact]
+        [TestPriority(10)]
         public async Task CanYankInvoice()
         {
             var client = new BindleClient(DEMO_SERVER_URL);

--- a/Bindle.Tests/Integration.cs
+++ b/Bindle.Tests/Integration.cs
@@ -1,11 +1,17 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using static Deislabs.Bindle.GetInvoiceOptions;
 
-using static Bindle.GetInvoiceOptions;
-
-namespace Bindle.Tests
+namespace Deislabs.Bindle.Tests
 {
     // To run this against the data assumed in the integration tests, run the Bindle server
     // to serve files on port 14044 from the test/data directory.  If you have Rust installed you can
@@ -13,7 +19,138 @@ namespace Bindle.Tests
     //
     // RUST_LOG=info cargo run --bin bindle-server --features="cli" -- -i 127.0.0.1:14044 -d <this_repo>/Bindle.Tests/data
 
-    public class Integration
+    // Alternatively if you set the variable BINDLE_SERVER_PATH to the relative path of bindle-server then the test will start and stop the server automatically
+    // e.g. if bindle is in a peer directory to bindle-dotnet and the debug build is being used then set the variable to "../../../../../bindle/target/debug"
+
+    public class IntegrationFixture : IDisposable
+    {
+        private Process process;
+        private string dataPath;
+        private string origFilePath;
+        private string copyFilePath;
+        public IntegrationFixture()
+        {
+            var bindlePath = Environment.GetEnvironmentVariable("BINDLE_SERVER_PATH");
+            if (!string.IsNullOrEmpty(bindlePath))
+            {
+                var fullPath = Path.GetFullPath(Path.Join(bindlePath, "bindle-server"));
+                dataPath = Path.GetFullPath(Path.Join("../../../data"));
+                Console.WriteLine($"Using Bindle Server Path: {fullPath}");
+                Console.WriteLine($"Using Test Data Path: {dataPath}");
+                var psi = new ProcessStartInfo
+                {
+                    FileName = fullPath,
+                    Arguments = $"-i 127.0.0.1:14044 -d {dataPath}",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                };
+                psi.Environment["RUST_LOG"] = "info";
+                process = new Process
+                {
+                    StartInfo = psi
+                };
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (!String.IsNullOrEmpty(e.Data))
+                    {
+                        Console.WriteLine(e.Data);
+                    }
+                };
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    if (!String.IsNullOrEmpty(e.Data))
+                    {
+                        Console.WriteLine(e.Data);
+                    }
+                };
+                process.Start();
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+                // TODO: something a bit less crappy that this to wait for server to start:
+                Thread.Sleep(5000);
+                Assert.False(process.HasExited);
+
+                // data/invoices/33d7f76b3077de5b72f50d3bf1997d6571770665732ac83b3bede75cf3c5fb67/invoice.toml gets modified by tests so take a copy so it can be reverted at the end.
+
+                origFilePath = Path.Join(dataPath, "invoices/33d7f76b3077de5b72f50d3bf1997d6571770665732ac83b3bede75cf3c5fb67/invoice.toml");
+                copyFilePath = Path.Join(dataPath, "invoices/33d7f76b3077de5b72f50d3bf1997d6571770665732ac83b3bede75cf3c5fb67/invoice.toml.copy");
+                File.Copy(origFilePath, copyFilePath);
+
+            }
+        }
+
+        public void Dispose()
+        {
+
+            // Stop the bindle server
+            try
+            {
+                process?.Kill();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to stop bindle process:{ex}");
+            }
+
+            // Delete the files and dirs that the tests created.
+
+            var dirs = new string[]
+            {
+                Path.Join(dataPath, "invoices/8fb420e8308462667f8e1585b7e768bf2e391aec9a29d13c968849c99ed5b0bf"),
+                Path.Join(dataPath, "parcels/460d5965e4d1909e8c7a3748a414956b7038ab5fd79937c9fcb2b214e6b0160a")
+            };
+
+            foreach (var dir in dirs)
+            {
+                if (Directory.Exists(dir))
+                {
+                    try
+                    {
+                        Directory.Delete(dir, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Failed to delete test invoice directory: {dir} : {ex}");
+                    }
+
+                }
+            }
+
+            // Revert the modifications
+            
+            if (File.Exists(copyFilePath))
+            {
+                try
+                {
+                    File.Move(copyFilePath, origFilePath, true);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to delete replace modified test invoice:{ex}");
+                }
+            }
+        }
+    }
+
+    // This is a quick and dirty way of ensuring that CanFetchInvoice runs before CanYankInvoice
+    public class AlphabeticalOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<T> OrderTestCases<T>(IEnumerable<T> testCases) where T : ITestCase
+        {
+            Console.WriteLine($"Test Case Order:");
+            var orderedTestCases = testCases.OrderBy(testCase => testCase.TestMethod.Method.Name);
+            foreach (var tc in orderedTestCases)
+            {
+                Console.WriteLine($"\t{tc.TestMethod.Method.Name}");
+                yield return tc;
+            }
+        }
+    }
+
+    [TestCaseOrderer("Deislabs.Bindle.Tests.AlphabeticalOrderer", "Bindle.Tests")]
+    public class Integration : IClassFixture<IntegrationFixture>
     {
         const string DEMO_SERVER_URL = "http://localhost:14044/v1";
 
@@ -44,8 +181,6 @@ namespace Bindle.Tests
         [Fact]
         public async Task CanCreateInvoices()
         {
-            // TODO: this results in creating the invoice, so it can't be run twice!
-            // For now you need to delete test/data/invoices/8fb420... and restart the Bindle server
             var client = new BindleClient(DEMO_SERVER_URL);
             var invoice = new Invoice(
                 bindleVersion: "1.0.0",
@@ -105,8 +240,9 @@ namespace Bindle.Tests
         public async Task CanYankInvoice()
         {
             var client = new BindleClient(DEMO_SERVER_URL);
-            await client.YankInvoice("your/fancy/bindle/0.3.0");  // TODO: use one that doesn't conflict with CanFetchInvoice (because Xunit parallelisation)
-            await Assert.ThrowsAsync<BindleYankedException>(async () => {
+            await client.YankInvoice("your/fancy/bindle/0.3.0"); 
+            await Assert.ThrowsAsync<BindleYankedException>(async () =>
+            {
                 await client.GetInvoice("your/fancy/bindle/0.3.0");
             });
             var invoice = await client.GetInvoice("your/fancy/bindle/0.3.0", IncludeYanked);

--- a/Bindle.Tests/IntegrationFixture.cs
+++ b/Bindle.Tests/IntegrationFixture.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Deislabs.Bindle.Tests
+{
+    public class IntegrationFixture : IDisposable
+    {
+        private readonly Process process;
+        private readonly string dataPath;
+        private readonly string testDataCopy;
+
+        // private readonly string[] testDirs;
+        public IntegrationFixture()
+        {
+            var bindlePath = Environment.GetEnvironmentVariable("BINDLE_SERVER_PATH");
+            if (!string.IsNullOrEmpty(bindlePath))
+            {
+                var fullPath = Path.GetFullPath(Path.Join(bindlePath, "bindle-server"));
+                dataPath = Path.GetFullPath(Path.Join("../../../data"));
+                Console.WriteLine($"Using Bindle Server Path: {fullPath}");
+                Console.WriteLine($"Using Test Data Path: {dataPath}");
+
+                // Take a copy of the test data to be used by the tests
+                testDataCopy = $"{Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())}/test-data-copy";
+                Console.WriteLine($"Copying Test Data to: {testDataCopy}");
+                CopyDirectory(dataPath, testDataCopy);
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = fullPath,
+                    Arguments = $"-i 127.0.0.1:14044 -d {dataPath}",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                };
+                psi.Environment["RUST_LOG"] = "info";
+                process = new Process
+                {
+                    StartInfo = psi
+                };
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (!String.IsNullOrEmpty(e.Data))
+                    {
+                        Console.WriteLine(e.Data);
+                    }
+                };
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    if (!String.IsNullOrEmpty(e.Data))
+                    {
+                        Console.WriteLine(e.Data);
+                    }
+                };
+                process.Start();
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+                // TODO: something a bit less crappy that this to wait for server to start:
+                Thread.Sleep(5000);
+                Assert.False(process.HasExited);             
+            }
+        }
+
+        public void Dispose()
+        {
+            // Stop the bindle server
+            try
+            {
+                process?.Kill();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to stop bindle process:{ex}");
+            }
+
+            // Revert the modifications to test data
+
+            var testOutput =  $"{Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())}/test-output";
+            Console.WriteLine($"Copying Test Output to: {testOutput}");
+
+            // Copy the output of the test to the temp directory and then delete it and replace with the original, then delete the copies
+
+            CopyDirectory(dataPath, testOutput); 
+            Directory.Delete(dataPath, true);  
+            CopyDirectory(testDataCopy, dataPath);
+            Directory.Delete(testDataCopy, true);
+            Directory.Delete(testOutput, true);      
+        }
+
+        private void CopyDirectory(string source, string dest)
+        {
+             Directory.CreateDirectory(dest);
+             foreach (var file in Directory.GetFiles(source))
+             {
+                 File.Copy(file, Path.Combine(dest, Path.GetFileName(file)), true);
+             }
+
+             foreach (var dir in Directory.GetDirectories(source))
+             {
+                 CopyDirectory(dir, Path.Combine(dest, Path.GetFileName(dir)));
+             }
+        }
+    }
+}

--- a/Bindle.Tests/TestPriorityAttribute.cs
+++ b/Bindle.Tests/TestPriorityAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Deislabs.Bindle.Tests
+{
+    
+    [AttributeUsage(AttributeTargets.Method)]
+    public class TestPriorityAttribute : Attribute
+    {
+        public int Priority { get; private set; }
+        public TestPriorityAttribute(int order)
+        {
+            Priority = order;
+        }
+    }
+}

--- a/Bindle.Tests/TestPriorityOrderer.cs
+++ b/Bindle.Tests/TestPriorityOrderer.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Deislabs.Bindle.Tests
+{
+    public class TestPriorityOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<T> OrderTestCases<T>(IEnumerable<T> testCases) where T : ITestCase
+        {
+            var testcasesByPriority = new SortedDictionary<int, List<T>>();
+            foreach (var testCase in testCases)
+            {
+                int priorty;
+                var attr = testCase.TestMethod.Method.GetCustomAttributes(typeof(TestPriorityAttribute)).FirstOrDefault();
+                priorty = attr == null ? 0 : attr.GetNamedArgument<int>("Priority");
+                if (!testcasesByPriority.TryGetValue(priorty, out var list))
+                {
+                    list = new List<T>();
+                    testcasesByPriority.Add(priorty, list);
+                }
+                list.Add(testCase);
+            }
+            Console.WriteLine($"Test Case Order:");
+            foreach (var testCaseGroup in testcasesByPriority)
+            {
+                 Console.WriteLine($"Priority:{testCaseGroup.Key}");
+                 foreach (var testCase in testCaseGroup.Value)
+                 {
+                     Console.WriteLine($"\t\t{testCase.TestMethod.Method.Name}");
+                      yield return testCase;
+                 }
+            }
+        }
+    }
+}

--- a/Bindle/Bindle.csproj
+++ b/Bindle/Bindle.csproj
@@ -4,10 +4,41 @@
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
+    <Authors>Ivan Towlson</Authors>
+    <Company>Microsoft</Company>
+    <Description>Provides a client for Bindle.WARNING: Bindle is experimental. It is not considered production-grade by its developers, neither is it "supported" software.</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Deislabs.Bindle</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/deislabs/wagi-dotnet</PackageProjectUrl>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageReleaseNotes>https://github.com/deislabs/wagi-dotnet/releases</PackageReleaseNotes>
+    <PackageTags>Bindle;</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <RootNamespace>Deislabs.Bindle</RootNamespace>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+    <MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Tomlyn" Version="0.1.2" />
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <None Include="docs\readme.md" Pack="true" PackagePath="" />
+    <!-- See https://github.com/NuGet/Home/issues/10791 -->
+    <!-- The following reference can be removed once this issue is resolved. -->
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="5.9.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Bindle/BindleClient.cs
+++ b/Bindle/BindleClient.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Tomlyn.Model;
 
-namespace Bindle
+namespace Deislabs.Bindle
 {
     public class BindleClient
     {

--- a/Bindle/DefensiveCopy.cs
+++ b/Bindle/DefensiveCopy.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Bindle
+namespace Deislabs.Bindle
 {
     internal static class DefensiveCopy
     {

--- a/Bindle/Exceptions.cs
+++ b/Bindle/Exceptions.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace Bindle
+namespace Deislabs.Bindle
 {
     public class BindleProtocolException: Exception
     {

--- a/Bindle/GetInvoiceOptions.cs
+++ b/Bindle/GetInvoiceOptions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Bindle
+namespace Deislabs.Bindle
 {
     [Flags]
     public enum GetInvoiceOptions

--- a/Bindle/InvoiceWriter.cs
+++ b/Bindle/InvoiceWriter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Bindle
+namespace Deislabs.Bindle
 {
     public class InvoiceWriter
     {

--- a/Bindle/Parser.cs
+++ b/Bindle/Parser.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Tomlyn.Model;
 
-namespace Bindle
+namespace Deislabs.Bindle
 {
     internal static class Parser
     {

--- a/Bindle/Schema.cs
+++ b/Bindle/Schema.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Tomlyn.Model;
 
-namespace Bindle
+namespace Deislabs.Bindle
 {
     // We can't use init properties here because we can't guarantee that
     // they will be initialised to non-null values; so we have to write an

--- a/Bindle/docs/readme.md
+++ b/Bindle/docs/readme.md
@@ -1,0 +1,5 @@
+# Bindle-dotnet
+
+This package provides a [Bindle](https://github.com/deislabs/bindle) Client for dotnet.
+
+***WARNING:*** Bindle is experimental. It is not considered production-grade by its developers, neither is it "supported" software.

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This change adds GH workflows to build, test, publish and release bindle-dotnet as a nuget package. 

Tests have been updated to start up a bindle server and reset test data.


