### PR TITLE
test against bindle-server v0.8.0

### DIFF
--- a/.github/workflows/build-publish-release.yml
+++ b/.github/workflows/build-publish-release.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         repository: deislabs/bindle
         path: bindleserver
-        ref: main
+        ref: v0.8.0
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
To match compatibility with go-bindle, we should be testing this client
against bindle-server v0.8.0 which does not require invoices to attach signatures. However we will need to implement it for 0.9 - tracking that in #14 

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>