### PR TITLE
remove publish matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,14 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Setup dotnet


### PR DESCRIPTION
There is no need to publish the package more than once.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>